### PR TITLE
Support vim ALE LSP client

### DIFF
--- a/src/helpers/Class/CommandRunner.ts
+++ b/src/helpers/Class/CommandRunner.ts
@@ -10,6 +10,7 @@ import { IConnectionLogger, InkWorkspace } from "../../types/types";
 
 import StoryRenderer from "./StoryRenderer";
 import WorkspaceManager from "./WorkspaceManager";
+import { getDefaultSettings, mergeSettings } from "../configuration";
 
 /**
  * Runs command sent by the client.
@@ -120,7 +121,11 @@ export default class CommandRunner {
       return;
     }
 
-    const settings = await this.workspaceManager.fetchDocumentConfigurationSettings(documentUri);
+    let documentSettings = await this.workspaceManager.fetchDocumentConfigurationSettings(documentUri);
+    let defaultSettings = getDefaultSettings();
+    let settings = mergeSettings(documentSettings, this.workspaceManager.initializationOptions);
+    settings = mergeSettings(settings, defaultSettings);
+
     const storyRenderer = play ? new StoryRenderer(this.connection) : undefined;
 
     this.compiler.compileStory(settings, workspace);

--- a/src/helpers/configuration.test.ts
+++ b/src/helpers/configuration.test.ts
@@ -3,7 +3,7 @@
 // See LICENSE in the project root for license information.
 
 import { determinePlatform, mergeSettings } from "../helpers/configuration";
-import { InkConfigurationSettings, PartialInkConfigurationSettings, Platform } from "../types/types";
+import { PartialInkConfigurationSettings, Platform } from "../types/types";
 
 describe("determinePlatform", () => {
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe("determinePlatform", () => {
 });
 
 describe("mergeSettings", () => {
-  const defaultSettings: InkConfigurationSettings = {
+  const defaultSettings: PartialInkConfigurationSettings = {
     mainStoryPath: "main.ink",
     inklecateExecutablePath: "inklecate",
     runThroughMono: false

--- a/src/helpers/configuration.ts
+++ b/src/helpers/configuration.ts
@@ -77,7 +77,7 @@ export function defaultInklecatePath(platform: Platform): string {
  */
 export function mergeSettings(
   settings: PartialInkConfigurationSettings,
-  defaultSettings: InkConfigurationSettings
+  defaultSettings: PartialInkConfigurationSettings
 ): InkConfigurationSettings {
   let inklecatePath = settings.inklecateExecutablePath;
   let mainStoryPath = settings.mainStoryPath;

--- a/src/helpers/install.test.ts
+++ b/src/helpers/install.test.ts
@@ -1,0 +1,67 @@
+import * as Fs from "fs-extra";
+import * as Os from "os";
+import * as Path from "path";
+
+import {
+  createConnection,
+  ProposedFeatures
+} from "vscode-languageserver/lib/main";
+
+import DocumentManager from "../helpers/Class/DocumentManager";
+import DiagnosticManager from "../helpers/Class/DiagnosticManager";
+import CompilationDirectoryManager from "../helpers/Class/CompilationDirectoryManager";
+import StoryRenderer from "../helpers/Class/StoryRenderer";
+import InklecateBackend from "../backends/InklecateBackend";
+import WorkspaceManager from "../helpers/Class/WorkspaceManager";
+
+import mockedLogger from "../tests/helpers/logger";
+import {
+  checkPlatformAndDownloadBinaryDependency
+} from "../helpers/install";
+
+
+Object.defineProperty(process, "argv", { value: ["foo", "bar", "--stdio"] })
+const connection = createConnection(ProposedFeatures.all);
+const logger = mockedLogger.logger;
+const documentManager = new DocumentManager();
+const diagnosticManager = new DiagnosticManager(connection, documentManager, logger);
+const compilationDirectoryManager = new CompilationDirectoryManager(logger);
+const storyRenderer = new StoryRenderer(connection);
+const inklecateBackend = new InklecateBackend(storyRenderer, diagnosticManager, logger);
+const workspaceManager = new WorkspaceManager(
+  connection,
+  documentManager,
+  compilationDirectoryManager,
+  inklecateBackend,
+  logger
+);
+
+describe("checkPlatformAndDownloadBinaryDependency", () => {
+  const tmpDirectory = Path.join(Os.tmpdir(), "ink.language.server.install.test");
+  const directoryPath = Path.join(tmpDirectory, "foo");
+  const filePath = Path.join(directoryPath, 'fakeInklecate');
+
+  beforeAll(() => {
+    Fs.mkdirpSync(directoryPath);
+    Fs.closeSync(Fs.openSync(Path.join(directoryPath, "fakeInklecate"), 'w'));
+  });
+
+  it("returns false when given a specific, bogus inklecate path", () => {
+    workspaceManager.initializationOptions.inklecateExecutablePath = "foo"
+    checkPlatformAndDownloadBinaryDependency(workspaceManager, logger, result => {
+      expect(result).toEqual(false);
+    })
+  });
+
+  it("returns true when given a specific, real inklecate path", () => {
+    workspaceManager.initializationOptions.inklecateExecutablePath = filePath;
+    checkPlatformAndDownloadBinaryDependency(workspaceManager, logger, result => {
+      expect(result).toEqual(true);
+    })
+  });
+
+  afterAll(() => {
+    Fs.removeSync(directoryPath);
+  });
+
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,7 @@ function createConnectionLogger(clientConnection: IConnection) {
 connection.onInitialize((params: InitializeParams) => {
   logger.console.info("Language Server connected.");
 
-  workspaceManager.initializeCapabilities(params);
+  workspaceManager.initialize(params);
 
   return {
     capabilities: {
@@ -96,13 +96,17 @@ connection.onInitialized(() => {
     });
   }
 
-  checkPlatformAndDownloadBinaryDependency(logger, success => {
+  checkPlatformAndDownloadBinaryDependency(workspaceManager, logger, success => {
     flagDefaultSettingsAsDirty();
     workspaceManager.initializeInkWorkspaces();
   });
 });
 
-connection.onDidChangeConfiguration(() => {
+connection.onDidChangeConfiguration(change => {
+  // Probably a v2 client, update workspace wide config settings from this message
+  if (!workspaceManager.capabilities.configuration && change.settings && change.settings.ink) {
+    workspaceManager.initializationOptions = change.settings.ink;
+  }
   documentManager.documentSettings.clear();
 });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,7 +73,7 @@ function createConnectionLogger(clientConnection: IConnection) {
 connection.onInitialize((params: InitializeParams) => {
   logger.console.info("Language Server connected.");
 
-  workspaceManager.initializeCapabilities(params.capabilities);
+  workspaceManager.initializeCapabilities(params);
 
   return {
     capabilities: {


### PR DESCRIPTION
This PR represents a set of changes to support [w0rp/ale](https://github.com/w0rp/ale), which is a vim plugin that provides linting, syntax checking, etc. It features LSP server integration, but it doesn't yet take advantage of LSP v3 features.

There are two commits, each with their own description. I'm happy to split them into two PRs if you'd like, though vim support isn't fully usable without both together.

<hr>

### Support compiling outside of a 'workspace'

Some language server clients - notably, vim with the ALE plugin - do not
actually support the concept of workspaces. What that client (and
presumably others that do not support workspaces) do is send over a
rootUri (or if they're very old, a rootPath) that describes the root of
*the* workspace.

This patch enables ink-language-server to support such clients - if they
do not explicitly indicate workspace support in the initialization
method, but do set a rootUri or rootPath - we assume that the path sent
by the client is the root of a singular workspace.

<hr>

### Support receiving v2 configuration notices

LSP v2 allowed sending a workspace config change notice, but didn't
fully support the concept of separate workspaces. Instead, they were
more like global settings.

This change tries to support that world - we try to detect if you
are a v2 client (you've sent a rootUri but do not support workspace
folders); and then we will accept global parameters from you.

We merge those global workspace parameters in everywhere - starting
from the most specific (document params, if we have them), to the
somewhat specific (global workspace params), and then finally to the
default settings.

We also allow setting things like ink.mainStoryPath via the
initializationOptions of the initialize method. We treat these settings
identically to global workspace parameters.